### PR TITLE
Flush writes to the logfile before calling the subprocess

### DIFF
--- a/scripts/update-all-remote-wn-clients
+++ b/scripts/update-all-remote-wn-clients
@@ -75,6 +75,7 @@ def call_updater(cfg, section, updater_script, log_dir, dry_run=False):
             b"Started at %s\nUser: %s\nCommand: %r\n\n"
             % (datetime.datetime.now(), local_user, cmd)
         )
+        log_file.flush()
         proc = Popen(
             ["sudo", "-H", "-u", local_user] + cmd,
             stdout=log_file,


### PR DESCRIPTION
This should avoid out-of-order output