### PR TITLE
Run osg-ca-manage from a Git checkout instead of a tarball install

### DIFF
--- a/rpm/hosted-ce-tools.spec
+++ b/rpm/hosted-ce-tools.spec
@@ -10,6 +10,11 @@ BuildArch: noarch
 Requires: python-six
 Requires: fetch-crl
 Requires: sudo
+%if 0%{?rhel} < 8
+Requires: git
+%else
+Requires: git-core
+%endif
 %systemd_requires
 
 

--- a/rpm/hosted-ce-tools.spec
+++ b/rpm/hosted-ce-tools.spec
@@ -11,11 +11,7 @@ Requires: python-six
 Requires: fetch-crl
 Requires: sudo
 Requires: wget
-%if 0%{?rhel} < 8
-Requires: git
-%else
-Requires: git-core
-%endif
+Requires: /usr/bin/git
 %systemd_requires
 
 

--- a/rpm/hosted-ce-tools.spec
+++ b/rpm/hosted-ce-tools.spec
@@ -10,6 +10,7 @@ BuildArch: noarch
 Requires: python-six
 Requires: fetch-crl
 Requires: sudo
+Requires: wget
 %if 0%{?rhel} < 8
 Requires: git
 %else

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -18,6 +18,7 @@ the remote host.
 from __future__ import print_function
 import contextlib
 import logging
+import time
 from optparse import OptionParser
 import os
 import shutil
@@ -197,9 +198,18 @@ def setup_osg_ca_scripts_dir(osg_ca_scripts_dir):
     running the script right from the git checkout.
 
     """
-    subprocess.check_call([
-        "git", "clone", "-b", OSG_CA_SCRIPTS_BRANCH, OSG_CA_SCRIPTS_REPO, osg_ca_scripts_dir
-    ])
+    retries = 3
+    while retries > 0:
+        ret = subprocess.call([
+            "git", "clone", "-b", OSG_CA_SCRIPTS_BRANCH, OSG_CA_SCRIPTS_REPO, osg_ca_scripts_dir
+        ])
+        if ret == 0:
+            break
+        if retries > 0:
+            log.warning("git clone failed; retrying")
+            time.sleep(30)
+        else:
+            raise Error("git clone failed")
     # osg-ca-manage can be run right from the git checkout with a few tweaks:
     # - Need to set $OSG_LOCATION to the root of the checkout (handled in setup_cas())
     # - Config file must be in $OSG_LOCATION/etc/osg/osg-update-certs.conf

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -30,6 +30,10 @@ import tempfile
 from six.moves import shlex_quote, urllib
 
 
+OSG_CA_SCRIPTS_REPO = "https://github.com/opensciencegrid/osg-ca-scripts"
+OSG_CA_SCRIPTS_BRANCH = "latest"
+
+
 devnull = open(os.devnull, "w+")
 log = logging.getLogger(__name__)
 
@@ -56,40 +60,21 @@ def download_to_file(uri, outfile):
         raise Error("Unable to save downloaded file to %s: %s" % (outfile, err))
 
 
-def setup_cas(wn_client, osgrun, cert_dir):
+def setup_cas(osg_ca_scripts_dir, cert_dir):
     "Run osg-ca-manage setupCA"
 
-    # Unfortunately, if we specify a location to osg-ca-manage setupCA, it
-    # always wants to create a symlink from
-    # $OSG_LOCATION/etc/grid-security/certificates to that location.  Since we
-    # do not want to mess up the tarball install we're using, we must first
-    # save the symlink that's already there, then run osg-ca-manage, then
-    # restore it.
-    certs_link = os.path.join(wn_client, "etc/grid-security/certificates")
-    certs_link_save = certs_link + ".save"
-
-    # Note that in a proper tarball install, certs_link should already exist
-    # but handle its nonexistence gracefully too.
-    # Note the need to use 'lexists' since 'exists' returns False if the path
-    # is a broken symlink.
-    if os.path.lexists(certs_link):
-        if os.path.lexists(certs_link_save):
-            os.unlink(certs_link_save)
-        os.rename(certs_link, certs_link_save)
+    environ = os.environ.copy()
+    environ["OSG_LOCATION"] = osg_ca_scripts_dir
+    environ["PERL5LIB"] = "%s:%s/lib" % (environ.get("PERL5LIB", ""), osg_ca_scripts_dir)
 
     # osg-ca-manage always puts the certs into a subdirectory called 'certificates'
     # under the location specified here. So specify the parent of cert_dir as --location.
-    command = [osgrun, "osg-ca-manage"]
+    command = ["./sbin/osg-ca-manage"]
     command += ["setupCA"]
     command += ["--location", os.path.dirname(cert_dir)]
     command += ["--url", "osg"]
-    try:
-        subprocess.check_call(command)
-    finally:
-        if os.path.lexists(certs_link_save):
-            if os.path.lexists(certs_link):
-                os.unlink(certs_link)
-            os.rename(certs_link_save, certs_link)
+    with chdir(osg_ca_scripts_dir):
+        subprocess.check_call(command, env=environ)
 
 
 def update_cas(osgrun, cert_dir):
@@ -204,6 +189,16 @@ def rsync_upload(local_dir, remote_user, remote_host, remote_dir, ssh_key=None):
         raise Error("Error renaming remote directories: %s" % e)
 
 
+def setup_osg_ca_scripts_dir(osg_ca_scripts_dir):
+    subprocess.check_call([
+        "git", "clone", "-b", OSG_CA_SCRIPTS_BRANCH, OSG_CA_SCRIPTS_REPO, osg_ca_scripts_dir
+    ])
+    with chdir(osg_ca_scripts_dir):
+        os.symlink(".", "usr")
+        os.mkdir("etc/osg")
+        os.symlink("../osg-update-certs.conf", "etc/osg/osg-update-certs.conf")
+
+
 @contextlib.contextmanager
 def working_dir(*args, **kwargs):
     """Resource manager for creating a temporary directory, cd'ing into it,
@@ -218,11 +213,13 @@ def working_dir(*args, **kwargs):
     shutil.rmtree(wd)
 
 
-# Because paths are embedded into the WN-client installation, two copies
-# of the client are used: the "deploy" client, which will be rsynced to the
-# worker node, and the "fetch" client, which will be used to download CAs
-# and CRLs.  The "fetch" client will put the CAs and CRLs into the certificate
-# dir of the "deploy" client.
+@contextlib.contextmanager
+def chdir(directory):
+    """Resource manager for cd'ing into an existing directory and going back to the old directory afterward."""
+    olddir = os.getcwd()
+    os.chdir(directory)
+    yield
+    os.chdir(olddir)
 
 
 def main():
@@ -267,18 +264,15 @@ def main():
             deploy_client_dir = os.path.join(wd, "deploy/osg-wn-client")
             cert_dir = os.path.join(deploy_client_dir, "etc/grid-security/certificates")
 
-            os.mkdir("fetch")
-            subprocess.check_call(["tar", "-C", "fetch", "-xzf", "osg-wn-client.tar.gz"])
-            fetch_client_dir = os.path.join(wd, "fetch/osg-wn-client")
+            osg_ca_scripts_dir = os.path.join(wd, "osg-ca-scripts")
+            setup_osg_ca_scripts_dir(osg_ca_scripts_dir)
 
             log.info("Setting up tarball dirs")
             subprocess.check_call([os.path.join(deploy_client_dir, "osg/osg-post-install"),
                                    "-f", opts.remote_dir])
-            subprocess.check_call([os.path.join(fetch_client_dir, "osg/osg-post-install")])
-            osgrun = os.path.join(fetch_client_dir, "osgrun")
 
             log.info("Fetching CAs")
-            setup_cas(fetch_client_dir, osgrun, cert_dir)
+            setup_cas(osg_ca_scripts_dir, cert_dir)
             log.info("Fetching CRLs")
             update_crls(cert_dir)
 

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -61,8 +61,15 @@ def download_to_file(uri, outfile):
 
 
 def setup_cas(osg_ca_scripts_dir, cert_dir):
-    "Run osg-ca-manage setupCA"
+    """Run osg-ca-manage setupCA from a git clone of osg-ca-scripts.
 
+    This will write CA certificates into cert_dir.  As a side effect, it will
+    also create a symlink in osg_ca_scripts_dir/etc/grid-security/certificates
+    but we can ignore that.
+
+    """
+    if not cert_dir.endswith("certificates"):  # required by osg-ca-manage
+        raise ValueError("cert_dir %r does not end in certificates" % cert_dir)
     environ = os.environ.copy()
     environ["OSG_LOCATION"] = osg_ca_scripts_dir
     environ["PERL5LIB"] = "%s:%s/lib" % (environ.get("PERL5LIB", ""), osg_ca_scripts_dir)
@@ -75,10 +82,6 @@ def setup_cas(osg_ca_scripts_dir, cert_dir):
     command += ["--url", "osg"]
     with chdir(osg_ca_scripts_dir):
         subprocess.check_call(command, env=environ)
-
-
-def update_cas(osgrun, cert_dir):
-    subprocess.check_call([osgrun, "osg-ca-manage", "--cert-dir", cert_dir, "refreshCA"])
 
 
 def update_crls(cert_dir):
@@ -190,9 +193,18 @@ def rsync_upload(local_dir, remote_user, remote_host, remote_dir, ssh_key=None):
 
 
 def setup_osg_ca_scripts_dir(osg_ca_scripts_dir):
+    """Clones the osg-ca-scripts repo and sets up dirs and symlinks to allow
+    running the script right from the git checkout.
+
+    """
     subprocess.check_call([
         "git", "clone", "-b", OSG_CA_SCRIPTS_BRANCH, OSG_CA_SCRIPTS_REPO, osg_ca_scripts_dir
     ])
+    # osg-ca-manage can be run right from the git checkout with a few tweaks:
+    # - Need to set $OSG_LOCATION to the root of the checkout (handled in setup_cas())
+    # - Config file must be in $OSG_LOCATION/etc/osg/osg-update-certs.conf
+    # - osg-setup-ca-certificates must be in $OSG_LOCATION/usr/libexec
+    # - OSGCerts.pem must be in Perl path (handled in setup_cas())
     with chdir(osg_ca_scripts_dir):
         os.symlink(".", "usr")
         os.mkdir("etc/osg")
@@ -215,7 +227,10 @@ def working_dir(*args, **kwargs):
 
 @contextlib.contextmanager
 def chdir(directory):
-    """Resource manager for cd'ing into an existing directory and going back to the old directory afterward."""
+    """Resource manager for cd'ing into an existing directory
+    and going back to the old directory afterward.
+
+    """
     olddir = os.getcwd()
     os.chdir(directory)
     yield

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -69,7 +69,7 @@ def setup_cas(osg_ca_scripts_dir, cert_dir):
     but we can ignore that.
 
     """
-    if not cert_dir.endswith("certificates"):  # required by osg-ca-manage
+    if os.path.basename(cert_dir) != "certificates":  # required by osg-ca-manage
         raise ValueError("cert_dir %r does not end in certificates" % cert_dir)
     environ = os.environ.copy()
     environ["OSG_LOCATION"] = osg_ca_scripts_dir
@@ -205,8 +205,9 @@ def setup_osg_ca_scripts_dir(osg_ca_scripts_dir):
         ])
         if ret == 0:
             break
+        retries -= 1
         if retries > 0:
-            log.warning("git clone failed; retrying")
+            log.warning("git clone failed; retrying in 30 seconds")
             time.sleep(30)
         else:
             raise Error("git clone failed")


### PR DESCRIPTION
This fixes SOFTWARE-4242 as well as simplifying the code by a bit, since we no longer create two installs (one to deploy, one just to run osg-ca-manage).