### PR TITLE
Remove the old wn-client installation after we've updated it

### DIFF
--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -183,12 +183,15 @@ def rsync_upload(local_dir, remote_user, remote_host, remote_dir, ssh_key=None):
     # then rename destdir to olddir and newdir to destdir
     try:
         log.info("Moving %s to %s", newdir, remote_dir)
+        olddir_q = shlex_quote(olddir)
+        remote_dir_q = shlex_quote(remote_dir)
+        newdir_q = shlex_quote(newdir)
         subprocess.check_call(ssh +
                               [remote_host,
-             "rm -rf {0} && "
-             "mv {1} {0} && "
-             "mv {2} {1}".format(
-                shlex_quote(olddir), shlex_quote(remote_dir), shlex_quote(newdir))])
+             "rm -rf {olddir_q} && "
+             "mv {remote_dir_q} {olddir_q} && "
+             "mv {newdir_q} {remote_dir_q} && "
+             "rm -rf {olddir_q}".format(**locals())])
     except (OSError, CalledProcessError) as e:
         raise Error("Error renaming remote directories: %s" % e)
 


### PR DESCRIPTION
A wn-client installation doesn't use much _space_ but it does use many _files_ (~4000) and if you have an inode quota, those can add up
