### PR TITLE
cvmfsexec-osg-wrapper should use cvmfsexec where available (SOFTWARE-4950)

### DIFF
--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -44,12 +44,6 @@ if [[ -z $CVMFSEXEC_REPOS ]]; then
     exec "$@"
 fi
 
-# We use $CVMFSEXEC_REPOS unquoted so check for bad characters
-badchars=$(grep -o '[^0-9a-zA-Z. -]' <<<"$CVMFSEXEC_REPOS")
-if [[ -n $badchars ]]; then
-    fail "Illegal character(s) $badchars in \$CVMFSEXEC_REPOS"
-fi
-
 job=("$@")
 
 fail () {
@@ -82,6 +76,12 @@ add_or_replace () {
 #
 # Begin
 #
+
+# We use $CVMFSEXEC_REPOS unquoted so check for bad characters
+badchars=$(grep -o '[^0-9a-zA-Z. -]' <<<"$CVMFSEXEC_REPOS")
+if [[ -n $badchars ]]; then
+    fail "Illegal character(s) $badchars in \$CVMFSEXEC_REPOS"
+fi
 
 set -o nounset
 PS4='+ ${LINENO}: '

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -34,14 +34,14 @@ CVMFSEXEC_REPOS=$(tr -s ',' ' ' <<<"${CVMFSEXEC_REPOS-}")
 CVMFS_HTTP_PROXY=${CVMFS_HTTP_PROXY-}
 UMOUNTREPO_UNMOUNT_ALL=${UMOUNTREPO_UNMOUNT_ALL-}
 
-if [[ -z $CVMFSEXEC_REPOS ]]; then
-    exec "$@"
-fi
-
 SAFE=false
 if [[ $1 = -safe ]]; then
     SAFE=true
     shift
+fi
+
+if [[ -z $CVMFSEXEC_REPOS ]]; then
+    exec "$@"
 fi
 
 job=("$@")

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -29,14 +29,6 @@ if [[ -z $CVMFSEXEC_REPOS ]]; then
     exec "$@"
 fi
 
-if [[ -z $CVMFS_HTTP_PROXY ]]; then
-    # TODO: This site-specific thing does not belong in this script.
-    if [[ ${TACC_SYSTEM-} = stampede2 ]]; then
-        CVMFS_HTTP_PROXY=http://login5.stampede2.tacc.utexas.edu:3128/
-    fi
-fi
-
-
 SAFE=false
 if [[ $1 = -safe ]]; then
     SAFE=true
@@ -115,14 +107,6 @@ fi
 
 # If we have to use this script to mount CVMFS, we can't use images from there anyway.
 export ALLOW_NONCVMFS_IMAGES=true
-
-# TODO: This site-specific thing does not belong in this script.
-if [[ -n ${TACC_SYSTEM-} ]]; then
-    echo >&2 "*** Adding $TACC_SYSTEM statements"
-    set +o nounset
-    module load tacc-singularity
-    set -o nounset
-fi
 
 echo >&2 "*** Running cvmfsexec smoke test:"
 if "$workdir"/cvmfsexec/cvmfsexec -N -- /bin/true; then

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -2,9 +2,9 @@
 #
 # cvmfsexec-osg-wrapper
 #
-# Runs the specified command with CVMFS repos mounted (using mountrepo)
-# in a temp directory; the directory will be in the command's environment
-# as $CVMFS_BASE.
+# Runs the specified command with CVMFS repos mounted (using cvmfsexec if
+# possible, otherwise mountrepo) in a temp directory; the directory will be
+# in the command's environment as $CVMFS_BASE.
 #
 # Clones the cvmfsexec repo from GitHub in order to create the environment;
 # checks out the latest tagged version.
@@ -30,6 +30,7 @@ if [[ -z $CVMFSEXEC_REPOS ]]; then
 fi
 
 if [[ -z $CVMFS_HTTP_PROXY ]]; then
+    # TODO: This site-specific thing does not belong in this script.
     if [[ ${TACC_SYSTEM-} = stampede2 ]]; then
         CVMFS_HTTP_PROXY=http://login5.stampede2.tacc.utexas.edu:3128/
     fi
@@ -75,8 +76,6 @@ add_or_replace () {
 # Begin
 #
 
-command -v fusermount >& /dev/null || fail "Required command 'fusermount' not found"
-
 set -o nounset
 PS4='+ ${LINENO}: '
 #set -x
@@ -114,30 +113,43 @@ if [[ -n $CVMFS_HTTP_PROXY ]]; then
     add_or_replace "$cvmfs_local_config" CVMFS_HTTP_PROXY "${CVMFS_HTTP_PROXY}"
 fi
 
-"$workdir"/cvmfsexec/umountrepo -a || :
-
-trap '"$workdir"/cvmfsexec/umountrepo -a; cd "$prevdir"; rm -rf "$workdir"' EXIT
-
-# Mount repos
-for repo in config-osg.opensciencegrid.org $CVMFSEXEC_REPOS; do
-    "$workdir"/cvmfsexec/mountrepo "$repo" || fail "Unable to mount cvmfs repo $repo"
-done
-
-export CVMFS_BASE="$workdir"/cvmfsexec/dist/cvmfs
-
-export GLIDEIN_SINGULARITY_BINDPATH="$CVMFS_BASE:/cvmfs"
-
 # If we have to use this script to mount CVMFS, we can't use images from there anyway.
 export ALLOW_NONCVMFS_IMAGES=true
 
-echo "*** cvmfs available at $CVMFS_BASE" >&2
-
+# TODO: This site-specific thing does not belong in this script.
 if [[ -n ${TACC_SYSTEM-} ]]; then
     echo >&2 "*** Adding $TACC_SYSTEM statements"
     set +o nounset
     module load tacc-singularity
+    set -o nounset
 fi
 
+echo >&2 "*** Running cvmfsexec smoke test:"
+if "$workdir"/cvmfsexec/cvmfsexec -N -- /bin/true; then
+    echo >&2 "*** cvmfsexec smoke test passed: you have the permissions to run cvmfsexec directly"
 
-# Note: do not use 'exec'; cleanup won't run
-"$@"
+    # Note: do not use 'exec'; cleanup won't run
+    export CVMFS_BASE=/cvmfs
+    export GLIDEIN_SINGULARITY_BINDPATH="$CVMFS_BASE:/cvmfs"
+    echo "*** cvmfs available at $CVMFS_BASE" >&2
+    "$workdir"/cvmfsexec/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
+else
+    echo >&2 "*** cvmfsexec smoke test failed: will use mountrepo instead"
+    command -v fusermount >& /dev/null || fail "Required command 'fusermount' not found"
+
+    "$workdir"/cvmfsexec/umountrepo -a || :
+
+    trap '"$workdir"/cvmfsexec/umountrepo -a; cd "$prevdir"; rm -rf "$workdir"' EXIT
+
+    # Mount repos
+    for repo in config-osg.opensciencegrid.org $CVMFSEXEC_REPOS; do
+        "$workdir"/cvmfsexec/mountrepo "$repo" || fail "Unable to mount cvmfs repo $repo"
+    done
+
+    export CVMFS_BASE="$workdir"/cvmfsexec/dist/cvmfs
+    export GLIDEIN_SINGULARITY_BINDPATH="$CVMFS_BASE:/cvmfs"
+    echo "*** cvmfs available at $CVMFS_BASE" >&2
+
+    # Note: do not use 'exec'; cleanup won't run
+    "$@"
+fi

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -21,9 +21,18 @@
 #
 # Then set CVMFSEXEC_REPOS in the environment to a comma-or-space-separated
 # list of CVMFS repos to mount.
+#
+# Other variables:
+# - CVMFS_HTTP_PROXY: the proxy to use for CVMFS
+# - UMOUNTREPO_UNMOUNT_ALL:
+#       no effect unless using `mountrepo`; set this to unmount all mounted
+#       repos before and after.  This makes cleanup more reliable but may
+#       conflict if multiple copies of this script are running, so only use
+#       it with whole-machine jobs.
 
 CVMFSEXEC_REPOS=$(tr -s ',' ' ' <<<"${CVMFSEXEC_REPOS-}")
 CVMFS_HTTP_PROXY=${CVMFS_HTTP_PROXY-}
+UMOUNTREPO_UNMOUNT_ALL=${UMOUNTREPO_UNMOUNT_ALL-}
 
 if [[ -z $CVMFSEXEC_REPOS ]]; then
     exec "$@"
@@ -125,9 +134,23 @@ else
     echo >&2 "*** cvmfsexec smoke test failed: will use mountrepo instead"
     command -v fusermount >& /dev/null || fail "Required command 'fusermount' not found"
 
-    "$workdir"/cvmfsexec/umountrepo -a || :
+    if [[ -n $UMOUNTREPO_UNMOUNT_ALL ]]; then
+        "$workdir"/cvmfsexec/umountrepo -a || :
+    fi
 
-    trap '"$workdir"/cvmfsexec/umountrepo -a; cd "$prevdir"; rm -rf "$workdir"' EXIT
+    mounted_repos=
+
+    unmount_repos () {
+        if [[ -n $UMOUNTREPO_UNMOUNT_ALL ]]; then
+            "$workdir"/cvmfsexec/umountrepo -a || :
+        else
+            for repo in $mounted_repos; do
+                "$workdir"/cvmfsexec/umountrepo "$repo" || :
+            done
+        fi
+    }
+
+    trap 'unmount_repos; cd "$prevdir"; rm -rf "$workdir"' EXIT
 
     # Mount repos
     for repo in config-osg.opensciencegrid.org $CVMFSEXEC_REPOS; do
@@ -136,6 +159,7 @@ else
             tail -n 20 "$workdir"/cvmfsexec/log/"$repo".log >&2
             fail "Unable to mount cvmfs repo $repo"
         fi
+        mounted_repos="$mounted_repos $repo"
     done
 
     # mountrepo can't mount CVMFS to `/cvmfs`.  Set $CVMFS_BASE to its

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -112,10 +112,14 @@ echo >&2 "*** Running cvmfsexec smoke test:"
 if "$workdir"/cvmfsexec/cvmfsexec -N -- /bin/true; then
     echo >&2 "*** cvmfsexec smoke test passed: you have the permissions to run cvmfsexec directly"
 
-    # Note: do not use 'exec'; cleanup won't run
+    # cvmfsexec lets us have CVMFS mounted at `/cvmfs`; set $CVMFS_BASE for
+    # consistency with the mountrepo path
+
     export CVMFS_BASE=/cvmfs
     export GLIDEIN_SINGULARITY_BINDPATH="$CVMFS_BASE:/cvmfs"
     echo "*** cvmfs available at $CVMFS_BASE" >&2
+
+    # Note: do not use 'exec'; cleanup won't run
     "$workdir"/cvmfsexec/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
 else
     echo >&2 "*** cvmfsexec smoke test failed: will use mountrepo instead"
@@ -133,6 +137,9 @@ else
             fail "Unable to mount cvmfs repo $repo"
         fi
     done
+
+    # mountrepo can't mount CVMFS to `/cvmfs`.  Set $CVMFS_BASE to its
+    # location so scripts know where to find it.
 
     export CVMFS_BASE="$workdir"/cvmfsexec/dist/cvmfs
     export GLIDEIN_SINGULARITY_BINDPATH="$CVMFS_BASE:/cvmfs"

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -127,7 +127,11 @@ else
 
     # Mount repos
     for repo in config-osg.opensciencegrid.org $CVMFSEXEC_REPOS; do
-        "$workdir"/cvmfsexec/mountrepo "$repo" || fail "Unable to mount cvmfs repo $repo"
+        if ! "$workdir"/cvmfsexec/mountrepo "$repo"; then
+            echo "$repo mount failed, dumping logs:" >&2
+            tail -n 20 "$workdir"/cvmfsexec/log/"$repo".log >&2
+            fail "Unable to mount cvmfs repo $repo"
+        fi
     done
 
     export CVMFS_BASE="$workdir"/cvmfsexec/dist/cvmfs

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -44,6 +44,12 @@ if [[ -z $CVMFSEXEC_REPOS ]]; then
     exec "$@"
 fi
 
+# We use $CVMFSEXEC_REPOS unquoted so check for bad characters
+badchars=$(grep -o '[^0-9a-zA-Z. -]' <<<"$CVMFSEXEC_REPOS")
+if [[ -n $badchars ]]; then
+    fail "Illegal character(s) $badchars in \$CVMFSEXEC_REPOS"
+fi
+
 job=("$@")
 
 fail () {
@@ -129,6 +135,7 @@ if "$workdir"/cvmfsexec/cvmfsexec -N -- /bin/true; then
     echo "*** cvmfs available at $CVMFS_BASE" >&2
 
     # Note: do not use 'exec'; cleanup won't run
+    # $CVMFSEXEC_REPOS is a space-separated list so it's unquoted on purpose.
     "$workdir"/cvmfsexec/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
 else
     echo >&2 "*** cvmfsexec smoke test failed: will use mountrepo instead"
@@ -154,6 +161,7 @@ else
     trap 'unmount_repos; cd "$prevdir"; rm -rf "$workdir"' EXIT
 
     # Mount repos
+    # $CVMFSEXEC_REPOS is a space-separated list so it's unquoted on purpose.
     for repo in config-osg.opensciencegrid.org $CVMFSEXEC_REPOS; do
         if ! "$workdir"/cvmfsexec/mountrepo "$repo"; then
             echo "$repo mount failed, dumping logs:" >&2

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -135,6 +135,7 @@ else
     command -v fusermount >& /dev/null || fail "Required command 'fusermount' not found"
 
     if [[ -n $UMOUNTREPO_UNMOUNT_ALL ]]; then
+        # Unmount repos from a previous run that couldn't clean up
         "$workdir"/cvmfsexec/umountrepo -a || :
     fi
 


### PR DESCRIPTION
- use cvmfsexec instead of mountrepo if possible (SOFTWARE-4950)
- Remove TACC-specific code
- dump cvmfsexec logs if we fail to mount a repo
