### PR TITLE
cvmfsexec-osg-wrapper: take cvmfsexec from tarball

### DIFF
--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -6,8 +6,10 @@
 # possible, otherwise mountrepo) in a temp directory; the directory will be
 # in the command's environment as $CVMFS_BASE.
 #
-# Clones the cvmfsexec repo from GitHub in order to create the environment;
-# checks out the latest tagged version.
+# Uses the tarball in $CVMFSEXEC_TARBALL to get an osg distribution of
+# cvmfsexec; if missing or empty, clones cvmfsexec from GitHub and builds
+# the distribution on the fly.
+#
 # Normally bails on an error; pass `-safe` as the first argument in order
 # to run the command anyway (without CVMFS).
 #
@@ -29,10 +31,12 @@
 #       repos before and after.  This makes cleanup more reliable but may
 #       conflict if multiple copies of this script are running, so only use
 #       it with whole-machine jobs.
+# - CVMFSEXEC_TARBALL: pre-created tarball containing cvmfsexec
 
 CVMFSEXEC_REPOS=$(tr -s ',' ' ' <<<"${CVMFSEXEC_REPOS-}")
 CVMFS_HTTP_PROXY=${CVMFS_HTTP_PROXY-}
 UMOUNTREPO_UNMOUNT_ALL=${UMOUNTREPO_UNMOUNT_ALL-}
+CVMFSEXEC_TARBALL=${CVMFSEXEC_TARBALL-}
 
 SAFE=false
 if [[ $1 = -safe ]]; then
@@ -87,6 +91,17 @@ set -o nounset
 PS4='+ ${LINENO}: '
 #set -x
 
+[[ $(uname -p) == "x86_64" ]] || fail "Only the x86_64 architecture is supported"
+grep -q '^ID_LIKE=.*rhel.*' /etc/os-release || fail "Only rhel-like distributions are supported"
+OS_VERSION_ID=$(grep '^VERSION_ID=' /etc/os-release | tr -d '"' | cut -d= -f2-)
+if [[ $OS_VERSION_ID = 7* ]]; then
+    distro=rhel7-x86_64
+elif [[ $OS_VERSION_ID = 8* ]]; then
+    distro=rhel8-x86_64
+else
+    fail "Unsupported OS version $OS_VERSION_ID"
+fi
+
 prevdir=$(pwd)
 if [[ -n ${CVMFSEXEC_WRAPPER_WORKDIR:-} ]]; then
     workdir=$CVMFSEXEC_WRAPPER_WORKDIR
@@ -100,19 +115,31 @@ trap 'cd "$prevdir"; rm -rf "$workdir"' EXIT
 cd "$workdir" || fail "Couldn't enter work dir $workdir"
 
 # Obtain cvmfsexec and the OSG CVMFS distribution
-git clone https://github.com/cvmfs/cvmfsexec || fail "Error downloading cvmfsexec from GitHub"
-cd cvmfsexec
-# Check out latest tagged version. Only git 2.0+ has "git tag --sort"
-version_tags=$(git tag --list 'v*' | sort -V)
-tag=$(tail -n 1 <<<"$version_tags")
-[[ -n $tag ]] || fail "Couldn't get latest tagged version"
-git checkout "$tag" || fail "Couldn't switch to $tag"
-./makedist osg || fail "Couldn't get osg cvmfs distribution"
+if [[ -f $CVMFSEXEC_TARBALL ]]; then
+    # We are given a tarball: use it
+    tar xzf "$CVMFSEXEC_TARBALL" || fail "Couldn't extract $CVMFSEXEC_TARBALL"
+    if [[ -d ./cvmfsexec/$distro ]]; then
+        cvmfsexec_dir=$workdir/cvmfsexec/$distro
+    else
+        cvmfsexec_dir=$workdir/cvmfsexec
+    fi
+else
+    # Make the CVMFS distribution ourselves because we don't have a tarball
+    git clone https://github.com/cvmfs/cvmfsexec || fail "Error downloading cvmfsexec from GitHub"
+    cd cvmfsexec
+    # Check out latest tagged version. Only git 2.0+ has "git tag --sort"
+    version_tags=$(git tag --list 'v*' | sort -V)
+    tag=$(tail -n 1 <<<"$version_tags")
+    [[ -n $tag ]] || fail "Couldn't get latest tagged version"
+    git checkout "$tag" || fail "Couldn't switch to $tag"
+    ./makedist osg || fail "Couldn't get osg cvmfs distribution"
+    cvmfsexec_dir=$workdir/cvmfsexec
+fi
 
 # Add local configuration if any
-cvmfs_local_config=$workdir/cvmfsexec/dist/etc/cvmfs/default.local
-if [[ -e $workdir/cvmfsexec/default.local ]]; then
-    cp -f "$workdir/cvmfsexec/default.local"  "$cvmfs_local_config"
+cvmfs_local_config=$cvmfsexec_dir/dist/etc/cvmfs/default.local
+if [[ -e $cvmfsexec_dir/default.local ]]; then
+    cp -f "$cvmfsexec_dir/default.local"  "$cvmfs_local_config"
 fi
 
 if [[ -n $CVMFS_HTTP_PROXY ]]; then
@@ -124,7 +151,7 @@ fi
 export ALLOW_NONCVMFS_IMAGES=true
 
 echo >&2 "*** Running cvmfsexec smoke test:"
-if "$workdir"/cvmfsexec/cvmfsexec -N -- /bin/true; then
+if "$cvmfsexec_dir"/cvmfsexec -N -- /bin/true; then
     echo >&2 "*** cvmfsexec smoke test passed: you have the permissions to run cvmfsexec directly"
 
     # cvmfsexec lets us have CVMFS mounted at `/cvmfs`; set $CVMFS_BASE for
@@ -136,24 +163,24 @@ if "$workdir"/cvmfsexec/cvmfsexec -N -- /bin/true; then
 
     # Note: do not use 'exec'; cleanup won't run
     # $CVMFSEXEC_REPOS is a space-separated list so it's unquoted on purpose.
-    "$workdir"/cvmfsexec/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
+    "$cvmfsexec_dir"/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
 else
     echo >&2 "*** cvmfsexec smoke test failed: will use mountrepo instead"
     command -v fusermount >& /dev/null || fail "Required command 'fusermount' not found"
 
     if [[ -n $UMOUNTREPO_UNMOUNT_ALL ]]; then
         # Unmount repos from a previous run that couldn't clean up
-        "$workdir"/cvmfsexec/umountrepo -a || :
+        "$cvmfsexec_dir"/umountrepo -a || :
     fi
 
     mounted_repos=
 
     unmount_repos () {
         if [[ -n $UMOUNTREPO_UNMOUNT_ALL ]]; then
-            "$workdir"/cvmfsexec/umountrepo -a || :
+            "$cvmfsexec_dir"/umountrepo -a || :
         else
             for repo in $mounted_repos; do
-                "$workdir"/cvmfsexec/umountrepo "$repo" || :
+                "$cvmfsexec_dir"/umountrepo "$repo" || :
             done
         fi
     }
@@ -163,9 +190,9 @@ else
     # Mount repos
     # $CVMFSEXEC_REPOS is a space-separated list so it's unquoted on purpose.
     for repo in config-osg.opensciencegrid.org $CVMFSEXEC_REPOS; do
-        if ! "$workdir"/cvmfsexec/mountrepo "$repo"; then
+        if ! "$cvmfsexec_dir"/mountrepo "$repo"; then
             echo "$repo mount failed, dumping logs:" >&2
-            tail -n 20 "$workdir"/cvmfsexec/log/"$repo".log >&2
+            tail -n 20 "$cvmfsexec_dir"/log/"$repo".log >&2
             fail "Unable to mount cvmfs repo $repo"
         fi
         mounted_repos="$mounted_repos $repo"
@@ -174,7 +201,7 @@ else
     # mountrepo can't mount CVMFS to `/cvmfs`.  Set $CVMFS_BASE to its
     # location so scripts know where to find it.
 
-    export CVMFS_BASE="$workdir"/cvmfsexec/dist/cvmfs
+    export CVMFS_BASE="$cvmfsexec_dir/dist/cvmfs"
     export GLIDEIN_SINGULARITY_BINDPATH="$CVMFS_BASE:/cvmfs"
     echo "*** cvmfs available at $CVMFS_BASE" >&2
 

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -44,18 +44,24 @@ if [[ $1 = -safe ]]; then
     shift
 fi
 
+msg () {
+    echo >&2 "*** $*"
+}
+
 if [[ -z $CVMFSEXEC_REPOS ]]; then
+    msg "\$CVMFSEXEC_REPOS not specified"
     exec "$@"
 fi
 
 job=("$@")
 
 fail () {
-    echo "$@" >&2
+    msg "$@"
     if $SAFE; then
         # so it shows up in environment dumps in the job
         export CVMFSEXEC_WRAPPER_FAILURE="$*"
-        echo "*** $0 failed; cvmfs will be unavailable ***" >&2
+        msg "$0 failed; cvmfs will be unavailable ***"
+        [[ -n ${prevdir-} ]] && cd "$prevdir"
         "${job[@]}"
         exit $?
     else
@@ -69,8 +75,8 @@ add_or_replace () {
     local var="$2"
     local value="$3"
 
-    if [[ -e $file ]] && grep -Eq "^${var}=" "$file"; then
-        sed -i -r -e "s^${var}=.*${var}=\"${value}\"" "$file"
+    if [[ -f $file ]] && grep -q "^${var}=" "$file"; then
+        sed -i -e "s^${var}=.*${var}=\"${value}\"" "$file"
     else
         echo "${var}=\"${value}\"" >> "$file"
     fi
@@ -143,29 +149,32 @@ if [[ -e $cvmfsexec_dir/default.local ]]; then
 fi
 
 if [[ -n $CVMFS_HTTP_PROXY ]]; then
-    echo >&2 "Setting CVMFS_HTTP_PROXY to ${CVMFS_HTTP_PROXY}"
+    msg "Setting CVMFS_HTTP_PROXY to ${CVMFS_HTTP_PROXY}"
     add_or_replace "$cvmfs_local_config" CVMFS_HTTP_PROXY "${CVMFS_HTTP_PROXY}"
 fi
 
 # If we have to use this script to mount CVMFS, we can't use images from there anyway.
 export ALLOW_NONCVMFS_IMAGES=true
 
-echo >&2 "*** Running cvmfsexec smoke test:"
+msg "Running cvmfsexec smoke test:"
 if "$cvmfsexec_dir"/cvmfsexec -N -- /bin/true; then
-    echo >&2 "*** cvmfsexec smoke test passed: you have the permissions to run cvmfsexec directly"
+    msg "cvmfsexec smoke test passed: we have the permissions to run cvmfsexec directly"
 
     # cvmfsexec lets us have CVMFS mounted at `/cvmfs`; set $CVMFS_BASE for
     # consistency with the mountrepo path
 
     export CVMFS_BASE=/cvmfs
     export GLIDEIN_SINGULARITY_BINDPATH="$CVMFS_BASE:/cvmfs"
-    echo "*** cvmfs available at $CVMFS_BASE" >&2
+    msg "CVMFS successfully mounted"
+    msg ""
+    msg "\$CVMFS_BASE=$CVMFS_BASE"
 
     # Note: do not use 'exec'; cleanup won't run
     # $CVMFSEXEC_REPOS is a space-separated list so it's unquoted on purpose.
+    cd "$prevdir"
     "$cvmfsexec_dir"/cvmfsexec -N $CVMFSEXEC_REPOS -- "$@"
 else
-    echo >&2 "*** cvmfsexec smoke test failed: will use mountrepo instead"
+    msg "cvmfsexec smoke test failed: we will use mountrepo instead"
     command -v fusermount >& /dev/null || fail "Required command 'fusermount' not found"
 
     if [[ -n $UMOUNTREPO_UNMOUNT_ALL ]]; then
@@ -191,7 +200,7 @@ else
     # $CVMFSEXEC_REPOS is a space-separated list so it's unquoted on purpose.
     for repo in config-osg.opensciencegrid.org $CVMFSEXEC_REPOS; do
         if ! "$cvmfsexec_dir"/mountrepo "$repo"; then
-            echo "$repo mount failed, dumping logs:" >&2
+            msg "$repo mount failed, dumping logs:"
             tail -n 20 "$cvmfsexec_dir"/log/"$repo".log >&2
             fail "Unable to mount cvmfs repo $repo"
         fi
@@ -203,8 +212,11 @@ else
 
     export CVMFS_BASE="$cvmfsexec_dir/dist/cvmfs"
     export GLIDEIN_SINGULARITY_BINDPATH="$CVMFS_BASE:/cvmfs"
-    echo "*** cvmfs available at $CVMFS_BASE" >&2
+    msg "CVMFS successfully mounted"
+    msg ""
+    msg "\$CVMFS_BASE=$CVMFS_BASE"
 
     # Note: do not use 'exec'; cleanup won't run
+    cd "$prevdir"
     "$@"
 fi

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -121,7 +121,24 @@ trap 'cd "$prevdir"; rm -rf "$workdir"' EXIT
 cd "$workdir" || fail "Couldn't enter work dir $workdir"
 
 # Obtain cvmfsexec and the OSG CVMFS distribution
-if [[ -f $CVMFSEXEC_TARBALL ]]; then
+if [[ $CVMFSEXEC_TARBALL = *://* ]]; then
+    # We are given a URL; download the tarball from there.
+    msg "Downloading $CVMFSEXEC_TARBALL"
+    errmsg="Couldn't download $CVMFSEXEC_TARBALL"
+    newname=cvmfsexec-osg.tar.gz
+    if command -v curl &>/dev/null; then
+        curl -LSso "$newname" "$CVMFSEXEC_TARBALL" || fail "$errmsg"
+    elif command -v wget &>/dev/null; then
+        wget -O "$newname" "$CVMFSEXEC_TARBALL" || fail "$errmsg"
+    elif command -v GET &>/dev/null; then
+        GET "$CVMFSEXEC_TARBALL" > "$newname" || fail "$errmsg"
+    else
+        fail "No program to download $CVMFSEXEC_TARBALL with"
+    fi
+    CVMFSEXEC_TARBALL=$newname
+fi
+
+if [[ -n $CVMFSEXEC_TARBALL ]]; then
     # We are given a tarball: use it
     tar xzf "$CVMFSEXEC_TARBALL" || fail "Couldn't extract $CVMFSEXEC_TARBALL"
     if [[ -d ./cvmfsexec/$distro ]]; then
@@ -130,8 +147,10 @@ if [[ -f $CVMFSEXEC_TARBALL ]]; then
         cvmfsexec_dir=$workdir/cvmfsexec
     fi
 else
-    # Make the CVMFS distribution ourselves because we don't have a tarball
-    git clone https://github.com/cvmfs/cvmfsexec || fail "Error downloading cvmfsexec from GitHub"
+    # Make the CVMFS distribution ourselves because we weren't given a tarball
+    msg "\$CVMFSEXEC_TARBALL not found or not specified"
+    command -v git &>/dev/null || fail "Required command 'git' not found"
+    git clone -c advice.detachedHead=false https://github.com/cvmfs/cvmfsexec || fail "Error downloading cvmfsexec from GitHub"
     cd cvmfsexec
     # Check out latest tagged version. Only git 2.0+ has "git tag --sort"
     version_tags=$(git tag --list 'v*' | sort -V)

--- a/scripts/make-cvmfsexec-tarball
+++ b/scripts/make-cvmfsexec-tarball
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
-# Create a tarball with a cvmfsexec distribution with the OSG config.
+# Create a tarball with cvmfsexec distributions (one for each RHEL-like distro)
+# with the OSG config.
 #
 # By default this uses the latest tagged version of cvmfsexec and creates the
 # tarball as "cvmfsexec-osg.tar.gz".  See --help for how to override that.
@@ -8,6 +9,7 @@
 
 DEFAULT_FILENAME=cvmfsexec-osg.tar.gz
 
+DISTROS=(rhel7-x86_64 rhel8-x86_64)
 
 prog=${0##*/}
 
@@ -20,11 +22,11 @@ usage () {
     cat >&2 <<END
 Usage: $prog [<options>] [<destfile>]"
 
-Makes a tarball with a cvmfsexec distribution with the OSG config.
+Makes a tarball with cvmfsexec distributions with the OSG config.
+The tarball will contain distributions for: ${DISTROS[*]}
 
     <destfile> is the path to the tarball file to create (default $DEFAULT_FILENAME)
 
-    -d|--distro [el7|el8]   the distribution (otherwise will use the current machine's distribution)
     -b|--branch|--tag <git branch or tag>
                             the git branch/tag of the cvmfsexec repo to check out
                             if not specified, will use the newest tagged version
@@ -33,21 +35,10 @@ END
 }
 
 destfile=$DEFAULT_FILENAME
-m=
 tag=
 while [[ $1 ]]; do
     case $1 in
         -h|--help) usage; exit 0 ;;
-        -d|--distro)
-            if [[ $2 ]]; then
-                m="-m $2-x86_64"
-                shift 2
-            else
-                echo >&2 "$1 requires an argument"
-                usage
-                exit 2
-            fi
-            ;;
         -b|--branch|--tag)
             if [[ $2 ]]; then
                 tag=$2
@@ -66,29 +57,42 @@ done
 
 set -o nounset
 set -e
-PS4='+ ${LINENO}: '
-set -x
+PS4='+ $LINENO: '
+#set -x
 
 workdir=$(mktemp -d -t "$prog-XXXXXX")
-trap 'rm -rf "$workdir"' ERR EXIT
+trap 'rm -rf "$workdir"' EXIT
 pushd "$workdir"
 
-git clone https://github.com/cvmfs/cvmfsexec || fail "Error downloading cvmfsexec from GitHub"
-cd cvmfsexec
+# Check out the whole original repo to get all the tags/branches.
+# We'll create individual copies for each distro.
 
+git clone --mirror https://github.com/cvmfs/cvmfsexec orig-repo.git || fail "Error downloading cvmfsexec from GitHub"
+pushd orig-repo.git
 if [[ -z $tag ]]; then
-    # Branch/tag not specified.  Check out latest tagged version.
+    ## Branch/tag not specified.  Check out latest tagged version.
     version_tags=$(git tag --list 'v*' | sort -V)
     # ^^ can't use "git tag --sort", it requires git 2.0+
     tag=$(tail -n 1 <<<"$version_tags")
     [[ -n $tag ]] || fail "Couldn't get latest tagged version"
 fi
+popd
 
-git checkout "$tag" || fail "Couldn't switch to $tag"
-./makedist $m osg || fail "Couldn't get osg distribution"
+mkdir cvmfsexec
+cd cvmfsexec
+
+for distro in ${DISTROS[*]}; do
+    echo "Cloning cvmfsexec $tag for $distro"
+    git clone -c advice.detachedHead=false -b "$tag" ../orig-repo.git "$distro"
+    pushd "$distro"
+    ./makedist -m $distro osg || fail "Couldn't get osg distribution for $distro"
+    popd
+done
+
+rm -rf orig-repo.git
 cd ..
-tar -czf cvmfsexec.tar.gz cvmfsexec/
-rm -rf cvmfsexec/ || :
+tar --exclude-vcs -czf cvmfsexec.tar.gz cvmfsexec/
+rm -rf cvmfsexec || :
 
 popd
 mv "$workdir/cvmfsexec.tar.gz" "$destfile"


### PR DESCRIPTION
Modify `make-cvmfsexec-tarball` to create a multi-distro tarball that can be reused.  Modify `cvmfsexec-osg-wrapper` such that if `$CVMFSEXEC_TARBALL` points to a tarball file, it will be used instead of setting up cvmfsexec on the fly.