### PR TITLE
Dereference hardlinks when extracting $CVMFSEXEC_TARBALL since some filesystems don't support hardlinks

### DIFF
--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -140,7 +140,7 @@ fi
 
 if [[ -n $CVMFSEXEC_TARBALL ]]; then
     # We are given a tarball: use it.  Turn hardlinks into copies since some filesystems don't support hardlinks
-    tar --hard-dereference xzf "$CVMFSEXEC_TARBALL" || fail "Couldn't extract $CVMFSEXEC_TARBALL"
+    tar --hard-dereference -xzf "$CVMFSEXEC_TARBALL" || fail "Couldn't extract $CVMFSEXEC_TARBALL"
     if [[ -d ./cvmfsexec/$distro ]]; then
         cvmfsexec_dir=$workdir/cvmfsexec/$distro
     else

--- a/scripts/cvmfsexec-osg-wrapper
+++ b/scripts/cvmfsexec-osg-wrapper
@@ -139,8 +139,8 @@ if [[ $CVMFSEXEC_TARBALL = *://* ]]; then
 fi
 
 if [[ -n $CVMFSEXEC_TARBALL ]]; then
-    # We are given a tarball: use it
-    tar xzf "$CVMFSEXEC_TARBALL" || fail "Couldn't extract $CVMFSEXEC_TARBALL"
+    # We are given a tarball: use it.  Turn hardlinks into copies since some filesystems don't support hardlinks
+    tar --hard-dereference xzf "$CVMFSEXEC_TARBALL" || fail "Couldn't extract $CVMFSEXEC_TARBALL"
     if [[ -d ./cvmfsexec/$distro ]]; then
         cvmfsexec_dir=$workdir/cvmfsexec/$distro
     else

--- a/scripts/make-cvmfsexec-tarball
+++ b/scripts/make-cvmfsexec-tarball
@@ -91,7 +91,7 @@ done
 
 rm -rf orig-repo.git
 cd ..
-tar --exclude-vcs -czf cvmfsexec.tar.gz cvmfsexec/
+tar --hard-dereference --exclude-vcs -czf cvmfsexec.tar.gz cvmfsexec/
 rm -rf cvmfsexec || :
 
 popd


### PR DESCRIPTION
(SOFTWARE-5254)