### PR TITLE
upgrade scripts to python3 (SOFTWARE-5131)

### DIFF
--- a/scripts/update-all-remote-wn-clients
+++ b/scripts/update-all-remote-wn-clients
@@ -1,5 +1,5 @@
-#!/usr/bin/env python2
-from __future__ import print_function
+#!/usr/bin/env python3
+
 import datetime
 import logging
 import pwd

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -155,7 +155,7 @@ def rsync_upload(local_dir, remote_user, remote_host, remote_dir, ssh_key=None):
     except OSError as e:
         raise Error(errstr + str(e))
     output, _ = proc.communicate()
-    output = output.decode()
+    output = output.decode("latin-1")
     if proc.returncode != 0:
         log.error(output)
         raise Error(errstr + "rsync exited with %d" % proc.returncode)

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # Requirements: Python 2.6+
 """Create or update a tarball-based worker node client installation on a
@@ -15,7 +15,7 @@ the remote host.
 
 """
 
-from __future__ import print_function
+
 import contextlib
 import logging
 import time
@@ -155,6 +155,7 @@ def rsync_upload(local_dir, remote_user, remote_host, remote_dir, ssh_key=None):
     except OSError as e:
         raise Error(errstr + str(e))
     output, _ = proc.communicate()
+    output = output.decode()
     if proc.returncode != 0:
         log.error(output)
         raise Error(errstr + "rsync exited with %d" % proc.returncode)


### PR DESCRIPTION
Looks like @matyasselmeci already put some effort into making these mostly python3-compatible.  The only thing that caught my eye is Popen.communicate()'s output is a bytes which can't be compared to str (unicode) objects, as was done.  Simple solution seemed to be just to upgrade (ie decode) the output bytes to a unicode str.