### PR TITLE
update release version with python3 fixes from previous PR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 0.11
+VERSION = 1.0-2
 NAME=hosted-ce-tools
 NAME_VERSION=$(NAME)-$(VERSION)
 HASH = $(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION = 1.0-2
+VERSION = 1.0
 NAME=hosted-ce-tools
 NAME_VERSION=$(NAME)-$(VERSION)
 HASH = $(shell git rev-parse HEAD)

--- a/rpm/hosted-ce-tools.spec
+++ b/rpm/hosted-ce-tools.spec
@@ -2,7 +2,7 @@
 Summary: Tools for managing OSG Hosted CEs
 Name: hosted-ce-tools
 Version: 1.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 License: Apache 2.0
 Url: https://github.com/opensciencegrid/hosted-ce-tools
 Source0: %{name}-%{version}.tar.gz
@@ -56,6 +56,9 @@ systemctl daemon-reload
 
 
 %changelog
+* Mon Mar 06 2023 Brian Lin <blin@cs.wisc.edu> - 1.0-2
+- Fix missed conversion to python3 (SOFTWARE-5131)
+
 * Thu Feb 09 2023 Carl Edquist <edquist@cs.wisc.edu> - 1.0-1
 - Release hosted-ce-tools 1.0 (SOFTWARE-5130)
 - Convert scripts to python3 (SOFTWARE-5131)


### PR DESCRIPTION
Update the release version to include the python3 fixes from https://github.com/opensciencegrid/hosted-ce-tools/pull/22