### PR TITLE
SOFTWARE-5131: el9 remove python six

### DIFF
--- a/rpm/hosted-ce-tools.spec
+++ b/rpm/hosted-ce-tools.spec
@@ -2,16 +2,11 @@
 Summary: Tools for managing OSG Hosted CEs
 Name: hosted-ce-tools
 Version: 1.0
-Release: 2%{?dist}
+Release: 3%{?dist}
 License: Apache 2.0
 Url: https://github.com/opensciencegrid/hosted-ce-tools
 Source0: %{name}-%{version}.tar.gz
 BuildArch: noarch
-%if 0%{?rhel} >= 8
-Requires: python2-six
-%else
-Requires: python-six
-%endif
 Requires: fetch-crl
 Requires: sudo
 Requires: wget
@@ -56,6 +51,9 @@ systemctl daemon-reload
 
 
 %changelog
+* Fri Jun 02 2023 Matt Westphall <westphall@wisc.edu> - 1.0-3
+- Remove dependency on python-six (SOFTWARE-5131)
+
 * Mon Mar 06 2023 Brian Lin <blin@cs.wisc.edu> - 1.0-2
 - Fix missed conversion to python3 (SOFTWARE-5131)
 

--- a/scripts/update-all-remote-wn-clients
+++ b/scripts/update-all-remote-wn-clients
@@ -9,7 +9,6 @@ import re
 from subprocess import Popen, STDOUT
 import sys
 
-# noinspection PyUnresolvedReferences
 import configparser
 
 

--- a/scripts/update-all-remote-wn-clients
+++ b/scripts/update-all-remote-wn-clients
@@ -10,7 +10,7 @@ from subprocess import Popen, STDOUT
 import sys
 
 # noinspection PyUnresolvedReferences
-from six.moves import configparser
+import configparser
 
 
 CONFIG_PATH = "/etc/endpoints.ini"

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -26,9 +26,9 @@ import subprocess
 from subprocess import CalledProcessError, Popen, PIPE, STDOUT
 import sys
 import tempfile
-
-# noinspection PyUnresolvedReferences
-from six.moves import shlex_quote, urllib
+import urllib
+import urllib.request, urllib.error
+from shlex import quote
 
 
 OSG_CA_SCRIPTS_REPO = "https://github.com/opensciencegrid/osg-ca-scripts"
@@ -149,7 +149,7 @@ def rsync_upload(local_dir, remote_user, remote_host, remote_dir, ssh_key=None):
     errstr = "Error rsyncing to remote host %s:%s: " % (remote_host, remote_dir)
     try:
         proc = Popen(
-            ssh + [remote_host, "[[ -e %s ]] || echo missing" % shlex_quote(remote_dir)],
+            ssh + [remote_host, "[[ -e %s ]] || echo missing" % quote(remote_dir)],
             stdout=PIPE,
         )
     except OSError as e:
@@ -189,7 +189,7 @@ def rsync_upload(local_dir, remote_user, remote_host, remote_dir, ssh_key=None):
              "rm -rf {0} && "
              "mv {1} {0} && "
              "mv {2} {1}".format(
-                shlex_quote(olddir), shlex_quote(remote_dir), shlex_quote(newdir))])
+                quote(olddir), quote(remote_dir), quote(newdir))])
     except (OSError, CalledProcessError) as e:
         raise Error("Error renaming remote directories: %s" % e)
 

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -26,7 +26,6 @@ import subprocess
 from subprocess import CalledProcessError, Popen, PIPE, STDOUT
 import sys
 import tempfile
-import urllib
 import urllib.request, urllib.error
 from shlex import quote
 


### PR DESCRIPTION
Note: This script depends on Perl by way of `osg-ca-scripts`, which it downloads directly from github. However, the RPM doesn't have Perl as a dependency. Brian and I discussed that this script is usually installed directly via a tarball rather than via RPM, so this missing dependency might be ok.