### PR TITLE
SOFTWARE-5131 perl dependency

### DIFF
--- a/rpm/hosted-ce-tools.spec
+++ b/rpm/hosted-ce-tools.spec
@@ -2,7 +2,7 @@
 Summary: Tools for managing OSG Hosted CEs
 Name: hosted-ce-tools
 Version: 1.0
-Release: 3%{?dist}
+Release: 4%{?dist}
 License: Apache 2.0
 Url: https://github.com/opensciencegrid/hosted-ce-tools
 Source0: %{name}-%{version}.tar.gz
@@ -10,6 +10,8 @@ BuildArch: noarch
 Requires: fetch-crl
 Requires: sudo
 Requires: wget
+Requires: rsync
+Requires: perl
 Requires: /usr/bin/git
 %systemd_requires
 
@@ -51,6 +53,9 @@ systemctl daemon-reload
 
 
 %changelog
+* Thu Jun 08 2023 Matt Westphall <westphall@wisc.edu> - 1.0-4
+- Add missing dependencies on perl and rsync to spec file (SOFTWARE-5131)
+
 * Fri Jun 02 2023 Matt Westphall <westphall@wisc.edu> - 1.0-3
 - Remove dependency on python-six (SOFTWARE-5131)
 

--- a/scripts/update-all-remote-wn-clients
+++ b/scripts/update-all-remote-wn-clients
@@ -174,7 +174,7 @@ def main():
     )
     opts, _ = parser.parse_args()
 
-    cfg = configparser.SafeConfigParser()
+    cfg = configparser.ConfigParser()
     cfg.read(opts.config)
 
     sections_list = list(x for x in cfg.sections() if x.startswith("Endpoint"))

--- a/scripts/update-remote-wn-client
+++ b/scripts/update-remote-wn-client
@@ -101,7 +101,7 @@ def update_crls(cert_dir):
     proc = Popen(command, stdout=PIPE, stderr=STDOUT)
     output, _ = proc.communicate()
     if proc.returncode != 0:
-        if output and ("CRL verification failed" in output or "Download error" in output):
+        if output and (b"CRL verification failed" in output or b"Download error" in output):
             # These errors aren't actually fatal; we'll send a less alarming
             # notification about them.
             log.info(output)


### PR DESCRIPTION
Add a perl dependency, and sneak in a couple extra fixes:
- `rsync` was also missing as a dependency
- `SafeConfigParser` is deprecated in python >3.2
- `proc.communicate` output changed from string to bytes in python 3