### PR TITLE
Revert "Use sudo timeout instead of timeout sudo"

### DIFF
--- a/scripts/update-all-remote-wn-clients
+++ b/scripts/update-all-remote-wn-clients
@@ -121,6 +121,11 @@ def call_updater(cfg, section, updater_script, log_dir, dry_run=False):
                cmd)
         )
         log_file.flush()
+        # while it's advantageous to have the timeout be closer to the process
+        # you're running, we have to use "timeout sudo" here instead of
+        # "sudo timeout" so we don't have to list the "timeout" command in the
+        # sudoers file.  If you have timeout in the sudoers, you might as
+        # well have ALL since timeout lets you run any other command...
         proc = Popen(
             timeout_cmd + ["sudo", "-n", "-H", "-u", local_user] + cmd,
             stdout=log_file,

--- a/scripts/update-all-remote-wn-clients
+++ b/scripts/update-all-remote-wn-clients
@@ -122,7 +122,7 @@ def call_updater(cfg, section, updater_script, log_dir, dry_run=False):
         )
         log_file.flush()
         proc = Popen(
-            ["sudo", "-n", "-H", "-u", local_user] + timeout_cmd + cmd,
+            timeout_cmd + ["sudo", "-n", "-H", "-u", local_user] + cmd,
             stdout=log_file,
             stderr=STDOUT,
             cwd="/",


### PR DESCRIPTION
it broke sudo-ing in the hosted CE since we explicitly listed the command we wanted sudo-able in the sudoers file, and it wasn't `timeout`. Add a comment explaining why this is the way it should be so I don't change it back in the future.